### PR TITLE
feat(webhook): Support for Webhook Name in Webhook Endpoints

### DIFF
--- a/backend/helpers/pluginhelper/api/connection_helper.go
+++ b/backend/helpers/pluginhelper/api/connection_helper.go
@@ -99,7 +99,20 @@ func (c *ConnectionApiHelper) Patch(connection interface{}, input *plugin.ApiRes
 	return c.save(connection, c.db.CreateOrUpdate)
 }
 
-// First finds connection from db  by parsing request input and decrypt it
+// PatchByName (Modify) a connection record based on request body by connection name
+func (c *ConnectionApiHelper) PatchByName(connection interface{}, input *plugin.ApiResourceInput) errors.Error {
+	err := c.FirstByName(connection, input.Params)
+	if err != nil {
+		return err
+	}
+	err = c.merge(connection, input.Body)
+	if err != nil {
+		return err
+	}
+	return c.save(connection, c.db.CreateOrUpdate)
+}
+
+// First finds connection from db by id, parsing request input and decrypt it
 func (c *ConnectionApiHelper) First(connection interface{}, params map[string]string) errors.Error {
 	connectionId := params["connectionId"]
 	if connectionId == "" {
@@ -115,6 +128,18 @@ func (c *ConnectionApiHelper) First(connection interface{}, params map[string]st
 // FirstById finds connection from db by id and decrypt it
 func (c *ConnectionApiHelper) FirstById(connection interface{}, id uint64) errors.Error {
 	return CallDB(c.db.First, connection, dal.Where("id = ?", id))
+}
+
+// FirstByName finds connection from db by name, parsing request input and decrypting it
+func (c *ConnectionApiHelper) FirstByName(connection interface{}, params map[string]string) errors.Error {
+	connectionName := params["connectionName"]
+	if connectionName == "" {
+		return errors.BadInput.New("missing connectionName")
+	}
+	if len(connectionName) > 100 {
+		return errors.BadInput.New("invalid connectionName")
+	}
+	return CallDB(c.db.First, connection, dal.Where("name = ?", connectionName))
 }
 
 // List returns all connections with password/token decrypted

--- a/backend/plugins/webhook/api/deployments.go
+++ b/backend/plugins/webhook/api/deployments.go
@@ -84,6 +84,31 @@ type WebhookDeploymentCommitReq struct {
 func PostDeployments(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.First(connection, input.Params)
+
+	return postDeployments(input, connection, err)
+}
+
+// PostDeploymentsByName
+// @Summary create deployment by webhook name
+// @Description Create deployment pipeline by webhook name.<br/>
+// @Description example1: {"repo_url":"devlake","commit_sha":"015e3d3b480e417aede5a1293bd61de9b0fd051d","start_time":"2020-01-01T12:00:00+00:00","end_time":"2020-01-01T12:59:59+00:00","environment":"PRODUCTION"}<br/>
+// @Description So we suggest request before task after deployment pipeline finish.
+// @Description Both cicd_pipeline and cicd_task will be created
+// @Tags plugins/webhook
+// @Param body body WebhookDeploymentReq true "json body"
+// @Success 200
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 403  {string} errcode.Error "Forbidden"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/webhook/connections/by-name/:connectionName/deployments [POST]
+func PostDeploymentsByName(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.WebhookConnection{}
+	err := connectionHelper.FirstByName(connection, input.Params)
+
+	return postDeployments(input, connection, err)
+}
+
+func postDeployments(input *plugin.ApiResourceInput, connection *models.WebhookConnection, err errors.Error) (*plugin.ApiResourceOutput, errors.Error) {
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/webhook/api/issues.go
+++ b/backend/plugins/webhook/api/issues.go
@@ -94,6 +94,25 @@ func saveIncidentRelatedRecordsFromIssue(db dal.Transaction, logger log.Logger, 
 func PostIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.First(connection, input.Params)
+	return postIssue(input, err, connection)
+}
+
+// PostIssueByName
+// @Summary receive a record as defined and save it
+// @Description receive a record as follow and save it, example: {"url":"","issue_key":"DLK-1234","title":"a feature from DLK","description":"","epic_key":"","type":"BUG","status":"TODO","original_status":"created","story_point":0,"resolution_date":null,"created_date":"2020-01-01T12:00:00+00:00","updated_date":null,"lead_time_minutes":0,"parent_issue_key":"DLK-1200","priority":"","original_estimate_minutes":0,"time_spent_minutes":0,"time_remaining_minutes":0,"creator_id":"user1131","creator_name":"Nick name 1","assignee_id":"user1132","assignee_name":"Nick name 2","severity":"","component":""}
+// @Tags plugins/webhook
+// @Param body body WebhookIssueRequest true "json body"
+// @Success 200  {string} noResponse ""
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/webhook/by-name/:connectionName/issues [POST]
+func PostIssueByName(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.WebhookConnection{}
+	err := connectionHelper.FirstByName(connection, input.Params)
+	return postIssue(input, err, connection)
+}
+
+func postIssue(input *plugin.ApiResourceInput, err errors.Error, connection *models.WebhookConnection) (*plugin.ApiResourceOutput, errors.Error) {
 	if err != nil {
 		return nil, err
 	}
@@ -212,6 +231,24 @@ func PostIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, error
 func CloseIssue(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.First(connection, input.Params)
+	return closeIssue(input, err, connection)
+}
+
+// CloseIssueByName
+// @Summary set issue's status to DONE
+// @Description set issue's status to DONE
+// @Tags plugins/webhook
+// @Success 200  {string} noResponse ""
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/webhook/by-name/:connectionName/issue/:issueKey/close [POST]
+func CloseIssueByName(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.WebhookConnection{}
+	err := connectionHelper.FirstByName(connection, input.Params)
+	return closeIssue(input, err, connection)
+}
+
+func closeIssue(input *plugin.ApiResourceInput, err errors.Error, connection *models.WebhookConnection) (*plugin.ApiResourceOutput, errors.Error) {
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -118,5 +118,11 @@ func (p Webhook) ApiResources() map[string]map[string]plugin.ApiResourceHandler 
 		"connections/by-name/:connectionName/deployments": {
 			"POST": api.PostDeploymentsByName,
 		},
+		"connections/by-name/:connectionName/issues": {
+			"POST": api.PostIssueByName,
+		},
+		"connections/by-name/:connectionName/issue/:issueKey/close": {
+			"POST": api.CloseIssueByName,
+		},
 	}
 }

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -115,5 +115,8 @@ func (p Webhook) ApiResources() map[string]map[string]plugin.ApiResourceHandler 
 			"PATCH":  api.PatchConnectionByName,
 			"DELETE": api.DeleteConnectionByName,
 		},
+		"connections/by-name/:connectionName/deployments": {
+			"POST": api.PostDeploymentsByName,
+		},
 	}
 }

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -110,5 +110,10 @@ func (p Webhook) ApiResources() map[string]map[string]plugin.ApiResourceHandler 
 		":connectionId/issue/:issueKey/close": {
 			"POST": api.CloseIssue,
 		},
+		"connections/by-name/:connectionName": {
+			"GET":    api.GetConnectionByName,
+			"PATCH":  api.PatchConnectionByName,
+			"DELETE": api.DeleteConnectionByName,
+		},
 	}
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This PR introduces new endpoints to the Webhook API that allow users to perform actions using connectionName instead of connectionId. The goal is to improve usability and simplify integration by enabling users to reference webhooks by their human-readable names, eliminating the need to manage and persist connectionId values.

Changes Introduced

	1.	New Endpoints:
	  •	Added endpoints prefixed with /by-name to explicitly handle connectionName:
	  •	POST /plugins/webhook/connections/by-name/:connectionName/deployments
	  •	POST /plugins/webhook/by-name/:connectionName/issues
	  •	POST /plugins/webhook/by-name/:connectionName/issue/:issueKey/close
	  •	DELETE /plugins/webhook/connections/by-name/:connectionName
	  •	GET /plugins/webhook/connections/by-name/:connectionName
	  •	PATCH /plugins/webhook/connections/by-name/:connectionName
	2.	Internal Logic:
	  •	Updated the Webhook API implementation to retrieve connections using connectionName.
	  •	Reused existing logic by delegating common operations to internal methods, ensuring no duplication of functionality.
	3.	Backward Compatibility:
	  •	Existing endpoints using connectionId remain unchanged, ensuring full backward compatibility with current integrations.

### Does this close any open issues?
No

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
