### PR TITLE
feat: adapt build workflow to push images to ghcr

### DIFF
--- a/.github/workflows/build-ghcr.yml
+++ b/.github/workflows/build-ghcr.yml
@@ -1,0 +1,273 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build-Images-Push-GHCR
+env:
+  GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+      - release-*
+      - feat-*
+      - bugfix-*
+  pull_request: # TODO remove
+
+jobs:
+  build-and-push-builder:
+    name: Build and Push devlake builder
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Convert Repository Owner to Lowercase
+        id: lowercase_repo_owner
+        run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push lake image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./backend
+          push: true
+          target: builder
+          tags: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:amd64-builder
+          platforms: linux/amd64
+          cache-from: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:amd64-builder
+          cache-to: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:amd64-builder
+
+  build-and-push-base:
+    name: Build and Push devlake base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Convert Repository Owner to Lowercase
+        id: lowercase_repo_owner
+        run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push lake image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./backend
+          push: true
+          target: base
+          tags: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:base
+          platforms: linux/amd64,linux/arm64
+          cache-from: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:base
+          cache-to: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:base
+
+  build-devlake:
+    needs: build-and-push-builder
+    name: Build and cache devlake
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["arm64", "amd64"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: get_short_sha
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Convert Repository Owner to Lowercase
+        id: lowercase_repo_owner
+        run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/cache@v3
+        with:
+          path: /tmp/devlake-build-cache-${{ matrix.platform }}
+          key: buildx-devlake-build-cache-${{ github.run_id }}-${{ matrix.platform }}
+      - name: Build and cache lake build
+        uses: docker/build-push-action@v3
+        with:
+          context: ./backend
+          push: false
+          target: build
+          tags: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:build-cache-${{ matrix.platform }}
+          platforms: linux/${{ matrix.platform }}
+          cache-from: ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:amd64-builder
+          cache-to: type=local,mode=min,dest=/tmp/devlake-build-cache-${{ matrix.platform }}
+          build-args: |
+            TAG=${{ github.ref_name }}
+            SHA=${{ steps.get_short_sha.outputs.SHORT_SHA }}
+  get-timestamp:
+    name: Get build timestamp
+    runs-on: ubuntu-latest
+    outputs:
+      timestamp: ${{ steps.ts.outputs.timestamp }}
+    steps:
+      - name: Get build timestamp
+        id: ts
+        run: echo "timestamp=$(date '+%y%m%d_%H%M%S')" >> $GITHUB_OUTPUT
+  build-and-push-devlake:
+    needs: [build-devlake, build-and-push-base, get-timestamp]
+    name: Build and Push devlake image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: get_short_sha
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Convert Repository Owner to Lowercase
+        id: lowercase_repo_owner
+        run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/cache@v3
+        with:
+          path: /tmp/devlake-build-cache-amd64
+          key: buildx-devlake-build-cache-${{ github.run_id }}-amd64
+      - uses: actions/cache@v3
+        with:
+          path: /tmp/devlake-build-cache-arm64
+          key: buildx-devlake-build-cache-${{ github.run_id }}-arm64
+      - name: Get push tags
+        id: get_push_tags
+        run: |
+          image_name=ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake
+          if [[ ${{ github.event_name }} == "pull_request" ]]; then
+              pr_number=${{ github.event.pull_request.number }}
+              echo "TAGS=${image_name}:pr-${pr_number}" >> $GITHUB_OUTPUT
+          elif printf ${{ github.ref }} | grep -Pq '^refs/tags/' && printf ${{ github.ref_name }} | grep -Pq '^v(\d+).(\d+).(\d+)$'; then
+              echo "TAGS=${image_name}:latest,${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          elif printf ${{ github.ref }} |grep -Pq '^refs/tags/'; then
+              echo "TAGS=${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+              echo "TAGS=${image_name}:${{ github.ref_name }}_${{ needs.get-timestamp.outputs.timestamp }}_${{ steps.get_short_sha.outputs.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and push lake image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.get_push_tags.outputs.TAGS }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: |
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:amd64-builder
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/devlake:base
+            type=local,src=/tmp/devlake-build-cache-amd64
+            type=local,src=/tmp/devlake-build-cache-arm64
+          build-args: |
+            TAG=${{ github.ref_name }}
+            SHA=${{ steps.get_short_sha.outputs.SHORT_SHA }}
+      - name: Clear cache
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            for (const arch of ['amd64', 'arm64']) {
+              try {
+                await github.rest.actions.deleteActionsCacheByKey({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  key: `buildx-devlake-build-cache-${context.runId}-${arch}`,
+                })
+                console.log(`Clear cache buildx-devlake-build-cache-${context.runId}-${arch}`)
+              } catch (e) {
+                console.warn(`Error clear cache buildx-devlake-build-cache-${context.runId}-${arch}: ${e}`)
+              }
+            }
+
+  build-and-push-other-image:
+    needs: [get-timestamp]
+    name: Build and Push ${{ matrix.build.name }} image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build:
+          - name: config-ui
+            image: devlake-config-ui
+            context: config-ui
+          - name: grafana
+            image: devlake-dashboard
+            context: grafana
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get short sha
+        id: get_short_sha
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Convert Repository Owner to Lowercase
+        id: lowercase_repo_owner
+        run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get push tags
+        id: get_push_tags
+        run: |
+          image_name=ghcr.io/${{ env.REPO_OWNER_LOWER }}/${{ matrix.build.image }}
+          if [[ ${{ github.event_name }} == "pull_request" ]]; then
+              pr_number=${{ github.event.pull_request.number }}
+              echo "TAGS=${image_name}:pr-${pr_number}" >> $GITHUB_OUTPUT
+          elif printf ${{ github.ref }} | grep -Pq '^refs/tags/' && printf ${{ github.ref_name }} | grep -Pq '^v(\d+).(\d+).(\d+)$'; then
+              echo "TAGS=${image_name}:latest,${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          elif printf ${{ github.ref }} |grep -Pq '^refs/tags/'; then
+              echo "TAGS=${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+              echo "TAGS=${image_name}:${{ github.ref_name }}_${{ needs.get-timestamp.outputs.timestamp }}_${{ steps.get_short_sha.outputs.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and push ${{ matrix.build.name }} image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.build.context }}
+          push: true
+          tags: ${{ steps.get_push_tags.outputs.TAGS }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
### Summary
What does this PR do?
Updated the build workflow to use GitHub Container Registry (GHCR) instead of DockerHub. Changes include:
- Modified environment variables and secrets for GHCR authentication.
- Updated image tags and cache configuration.

### Does this close any open issues?
No

### Other Information
The change aligns the image hosting strategy with GitHub's integrated services for better maintainability and security.
